### PR TITLE
Fix JWS base 64 encoding

### DIFF
--- a/source/JSONWebToken-Core.package/Base64UrlEncoder.class/README.md
+++ b/source/JSONWebToken-Core.package/Base64UrlEncoder.class/README.md
@@ -1,0 +1,5 @@
+I am encoder/decoder for base 64 using an alphabet that's URL and filename safe according to https://tools.ietf.org/html/rfc4648#page-5.
+
+Base64 encoding is a technique to encode binary data as a string of characters that can be safely transported over various protocols. 
+Basically, every 3 bytes are encoded using 4 characters from an alphabet of 64. Each encoded character represents 6 bits.
+

--- a/source/JSONWebToken-Core.package/Base64UrlEncoder.class/class/initialize.st
+++ b/source/JSONWebToken-Core.package/Base64UrlEncoder.class/class/initialize.st
@@ -1,0 +1,4 @@
+class initialization
+initialize
+
+	URLSafeAlphabet := String withAll: ( $A to: $Z ) , ( $a to: $z ) , ( $0 to: $9 ) , #($- $_)

--- a/source/JSONWebToken-Core.package/Base64UrlEncoder.class/instance/decode..st
+++ b/source/JSONWebToken-Core.package/Base64UrlEncoder.class/instance/decode..st
@@ -1,0 +1,4 @@
+converting
+decode: string
+
+	^ encoder decode: string

--- a/source/JSONWebToken-Core.package/Base64UrlEncoder.class/instance/encode..st
+++ b/source/JSONWebToken-Core.package/Base64UrlEncoder.class/instance/encode..st
@@ -1,0 +1,4 @@
+converting
+encode: byteArray
+
+	^ encoder encode: byteArray

--- a/source/JSONWebToken-Core.package/Base64UrlEncoder.class/instance/initialize.st
+++ b/source/JSONWebToken-Core.package/Base64UrlEncoder.class/instance/initialize.st
@@ -1,0 +1,6 @@
+initialization
+initialize
+
+	super initialize.
+	encoder := ZnBase64Encoder new.
+	encoder alphabet: URLSafeAlphabet

--- a/source/JSONWebToken-Core.package/Base64UrlEncoder.class/properties.json
+++ b/source/JSONWebToken-Core.package/Base64UrlEncoder.class/properties.json
@@ -1,0 +1,15 @@
+{
+	"commentStamp" : "GOC 12/4/2019 13:05",
+	"super" : "Object",
+	"category" : "JSONWebToken-Core-Serialization",
+	"classinstvars" : [ ],
+	"pools" : [ ],
+	"classvars" : [
+		"URLSafeAlphabet"
+	],
+	"instvars" : [
+		"encoder"
+	],
+	"name" : "Base64UrlEncoder",
+	"type" : "normal"
+}

--- a/source/JSONWebToken-Core.package/JWSCompactSerializer.class/instance/materialize.key.checkSignature..st
+++ b/source/JSONWebToken-Core.package/JWSCompactSerializer.class/instance/materialize.key.checkSignature..st
@@ -1,11 +1,13 @@
 reading
 materialize: aString key: aKeyString checkSignature: checkSignature
-	| parts header jws  |
-	parts := $. split: aString. 
-	header := JWSHeader fromJson: (parts at: 1) base64Padded base64Decoded asString.
+
+	| parts header jws |
+
+	parts := $. split: aString.
+	header := JWSHeader fromJson: ( self base64Decoded: parts first ) asString.
 	jws := JsonWebSignature new
 		key: aKeyString;
 		setProtectedHeader: header.
-	checkSignature ifTrue: [  
-		jws checkSignature: parts  ]. 
-	^ jws payload: (JWTClaimsSet fromJson: parts second base64Padded base64Decoded asString) 
+	checkSignature
+		ifTrue: [ jws checkSignature: parts ].
+	^ jws payload: ( JWTClaimsSet fromJson: ( self base64Decoded: parts second ) asString )

--- a/source/JSONWebToken-Core.package/JWSSerializer.class/instance/base64Decoded..st
+++ b/source/JSONWebToken-Core.package/JWSSerializer.class/instance/base64Decoded..st
@@ -1,0 +1,7 @@
+conversion
+base64Decoded: aBase64String
+
+	"According to https://tools.ietf.org/html/rfc7519#page-4 the encoding needs to be base64Url.
+	The padding can be stripped as it is not used for transport in JWT, so we need to pad it just in case"
+
+	^ Base64UrlEncoder new decode: aBase64String base64Padded

--- a/source/JSONWebToken-Core.package/JWSSerializer.class/instance/base64Encoded..st
+++ b/source/JSONWebToken-Core.package/JWSSerializer.class/instance/base64Encoded..st
@@ -1,5 +1,7 @@
 conversion
 base64Encoded: aByteArray
-	"base64 encode and strip padding as it is not used for transport 
-	in JWT"
-	^ aByteArray base64Encoded copyWithoutAll: '='
+
+	"According to https://tools.ietf.org/html/rfc7519#page-4 the encoding needs to be base64Url.
+	The padding is stripped as it is not used for transport in JWT"
+
+	^ ( Base64UrlEncoder new encode: aByteArray ) copyWithoutAll: '='

--- a/source/JSONWebToken-Core.package/JsonWebSignature.class/instance/base64Decoded..st
+++ b/source/JSONWebToken-Core.package/JsonWebSignature.class/instance/base64Decoded..st
@@ -1,0 +1,4 @@
+private
+base64Decoded: aBase64String
+
+	^ Base64UrlEncoder new decode: aBase64String base64Padded

--- a/source/JSONWebToken-Core.package/JsonWebSignature.class/instance/checkSignature..st
+++ b/source/JSONWebToken-Core.package/JsonWebSignature.class/instance/checkSignature..st
@@ -1,4 +1,5 @@
 signature
 checkSignature: parts
-	((self signatureFor: ($. join: { parts first . parts second })) = parts third base64Padded base64Decoded asByteArray) ifFalse: [
-		Error signal: 'signature does not match' ].
+
+	( self signatureFor:( $. join: {parts first. parts second} ) ) = ( self base64Decoded: parts third  )
+		ifFalse: [ Error signal: 'signature does not match' ]

--- a/source/JSONWebToken-Tests.package/Base64UrlEncoderTest.class/README.md
+++ b/source/JSONWebToken-Tests.package/Base64UrlEncoderTest.class/README.md
@@ -1,0 +1,1 @@
+A Base64UrlEncoderTest is a test class for testing the behavior of Base64UrlEncoder

--- a/source/JSONWebToken-Tests.package/Base64UrlEncoderTest.class/instance/setUp.st
+++ b/source/JSONWebToken-Tests.package/Base64UrlEncoderTest.class/instance/setUp.st
@@ -1,0 +1,5 @@
+running
+setUp
+
+	super setUp.
+	encoder := Base64UrlEncoder new

--- a/source/JSONWebToken-Tests.package/Base64UrlEncoderTest.class/instance/testComparisonAgainstBase64.st
+++ b/source/JSONWebToken-Tests.package/Base64UrlEncoderTest.class/instance/testComparisonAgainstBase64.st
@@ -1,0 +1,6 @@
+tests
+testComparisonAgainstBase64
+
+	self
+		assert: #[87 6 86 119 38 150 198 198 254 255] base64Encoded equals: 'VwZWdyaWxsb+/w==';
+		assert: ( encoder encode: #[87 6 86 119 38 150 198 198 254 255] ) equals: 'VwZWdyaWxsb-_w=='

--- a/source/JSONWebToken-Tests.package/Base64UrlEncoderTest.class/instance/testDecode.st
+++ b/source/JSONWebToken-Tests.package/Base64UrlEncoderTest.class/instance/testDecode.st
@@ -1,0 +1,4 @@
+tests
+testDecode
+
+	self assert: ( encoder decode: 'VwZWdyaWxsb-_w==' ) equals: #[87 6 86 119 38 150 198 198 254 255]

--- a/source/JSONWebToken-Tests.package/Base64UrlEncoderTest.class/instance/testEncode.st
+++ b/source/JSONWebToken-Tests.package/Base64UrlEncoderTest.class/instance/testEncode.st
@@ -1,0 +1,4 @@
+tests
+testEncode
+
+	self assert: ( encoder encode: #[87 6 86 119 38 150 198 198 254 255] ) equals: 'VwZWdyaWxsb-_w=='

--- a/source/JSONWebToken-Tests.package/Base64UrlEncoderTest.class/properties.json
+++ b/source/JSONWebToken-Tests.package/Base64UrlEncoderTest.class/properties.json
@@ -1,0 +1,13 @@
+{
+	"commentStamp" : "<historical>",
+	"super" : "TestCase",
+	"category" : "JSONWebToken-Tests",
+	"classinstvars" : [ ],
+	"pools" : [ ],
+	"classvars" : [ ],
+	"instvars" : [
+		"encoder"
+	],
+	"name" : "Base64UrlEncoderTest",
+	"type" : "normal"
+}

--- a/source/JSONWebToken-Tests.package/JSONWebTokenTest.class/instance/testEncoding.st
+++ b/source/JSONWebToken-Tests.package/JSONWebTokenTest.class/instance/testEncoding.st
@@ -1,0 +1,23 @@
+tests
+testEncoding
+
+	"This test verifies the token serialization against https://jwt.io/"
+
+	| jws tokenString |
+
+	jws := JsonWebSignature new
+		algorithmName: 'HS256';
+		payload:
+			( JWTClaimsSet new
+				at: 'scope'
+					put:
+					'read:operations read:metrics execute:health-check read:application-info execute:application-control read:application-configuration';
+				yourself ).
+	jws key: '69YLYMC02jLExrrkcR@NhrZaj%Xw^VFfK*r34uRWvl3e91N3es'.
+
+	tokenString := jws compactSerialized.
+
+	self
+		assert: tokenString
+		equals:
+			'eyJhbGciOiJIUzI1NiJ9.eyJzY29wZSI6InJlYWQ6b3BlcmF0aW9ucyByZWFkOm1ldHJpY3MgZXhlY3V0ZTpoZWFsdGgtY2hlY2sgcmVhZDphcHBsaWNhdGlvbi1pbmZvIGV4ZWN1dGU6YXBwbGljYXRpb24tY29udHJvbCByZWFkOmFwcGxpY2F0aW9uLWNvbmZpZ3VyYXRpb24ifQ.-3meQq_ATpkE4FwFefP0AEBrFh9_llQxVXjnf-HLrIU'


### PR DESCRIPTION
According  to [RFC7519](https://tools.ietf.org/html/rfc7519#page-4) the encoding needs to be base64Url (the URL and Filename safe version) and not standard base64.

Section 3 of the RFC:

> A JWT is represented as a sequence of URL-safe parts separated by
>    period ('.') characters.  Each part contains a **base64url-encoded**
>    value.  The number of parts in the JWT is dependent upon the
>    representation of the resulting JWS using the JWS Compact
>    Serialization or JWE using the JWE Compact Serialization.

Base64URL encoding is explained in [ section 5 of RFC 4648](https://tools.ietf.org/html/rfc4648#page-5)