### PR TITLE
Add an optional "lenient" access mode for claims (implements #24)

### DIFF
--- a/source/JSONWebToken-Core.package/JWTClaimsSet.class/instance/at..st
+++ b/source/JSONWebToken-Core.package/JWTClaimsSet.class/instance/at..st
@@ -1,3 +1,6 @@
 accessing - basic
-at: aString 
-	^ claims at: aString
+at: aString
+
+	^ strict
+		  ifTrue: [ claims at: aString ]
+		  ifFalse: [ claims at: aString ifAbsent: [  ] ]

--- a/source/JSONWebToken-Core.package/JWTClaimsSet.class/instance/beLenient.st
+++ b/source/JSONWebToken-Core.package/JWTClaimsSet.class/instance/beLenient.st
@@ -1,0 +1,4 @@
+public
+beLenient
+
+	strict := false

--- a/source/JSONWebToken-Core.package/JWTClaimsSet.class/instance/beStrict.st
+++ b/source/JSONWebToken-Core.package/JWTClaimsSet.class/instance/beStrict.st
@@ -1,0 +1,4 @@
+public
+beStrict
+
+	strict := true

--- a/source/JSONWebToken-Core.package/JWTClaimsSet.class/instance/initialize.st
+++ b/source/JSONWebToken-Core.package/JWTClaimsSet.class/instance/initialize.st
@@ -2,3 +2,4 @@ initialize
 initialize
 	super initialize.
 	claims := Dictionary new.
+	strict := true

--- a/source/JSONWebToken-Core.package/JWTClaimsSet.class/properties.json
+++ b/source/JSONWebToken-Core.package/JWTClaimsSet.class/properties.json
@@ -6,7 +6,8 @@
 	"pools" : [ ],
 	"classvars" : [ ],
 	"instvars" : [
-		"claims"
+		"claims",
+		"strict"
 	],
 	"name" : "JWTClaimsSet",
 	"type" : "normal"


### PR DESCRIPTION
Makes #at: return nil for absent keys rather than raising an error, similar to how it works in JavaScript itself