### PR TITLE
Make the JOSE and subclass header properties accessible via #at: and …

### DIFF
--- a/source/JSONWebToken-Core/JOSEHeader.class.st
+++ b/source/JSONWebToken-Core/JOSEHeader.class.st
@@ -26,6 +26,16 @@ JOSEHeader >> = aHeader [
 	^ aHeader hasSameElements: properties
 ]
 
+{ #category : 'accessing' }
+JOSEHeader >> at: aKey [
+	^ properties at: aKey
+]
+
+{ #category : 'accessing' }
+JOSEHeader >> at: aKey put: aValue [
+	properties at: aKey put: aValue
+]
+
 { #category : 'testing' }
 JOSEHeader >> hasSameElements: aDictionary [
 	^ (properties difference: aDictionary) isEmpty
@@ -34,6 +44,17 @@ JOSEHeader >> hasSameElements: aDictionary [
 { #category : 'comparing' }
 JOSEHeader >> hash [
 	^ properties hash
+]
+
+{ #category : 'accessing' }
+JOSEHeader >> kid [
+"Public Key ID"
+	^ properties at: 'kid'
+]
+
+{ #category : 'accessing' }
+JOSEHeader >> kid: anObject [
+	properties at: 'kid' put: anObject
 ]
 
 { #category : 'accessing' }

--- a/source/JSONWebToken-Core/JWTClaimsSet.class.st
+++ b/source/JSONWebToken-Core/JWTClaimsSet.class.st
@@ -1,5 +1,8 @@
 "
 A set of specific claims
+
+The registered claim names are: iss, sub, aud, exp, nbf, iat, jti
+None of the claims defined are intended to be mandatory to use or implement in all cases, but rather they provide a starting point for a set of useful, interoperable claims.
 "
 Class {
 	#name : 'JWTClaimsSet',
@@ -192,8 +195,38 @@ JWTClaimsSet >> issuer: anObject [
 ]
 
 { #category : 'accessing' }
+JWTClaimsSet >> jti [
+	^ self at: 'jti'
+]
+
+{ #category : 'accessing' }
+JWTClaimsSet >> jti: aString [
+	self at: 'jti' put: aString
+]
+
+{ #category : 'accessing' }
+JWTClaimsSet >> jwtId [
+	^ self jti
+]
+
+{ #category : 'accessing' }
+JWTClaimsSet >> jwtId: aString [
+	self jti: aString
+]
+
+{ #category : 'accessing' }
 JWTClaimsSet >> mimeType [
 	^ 'JWT'
+]
+
+{ #category : 'accessing' }
+JWTClaimsSet >> nbf [
+	^ self at: 'nbf'
+]
+
+{ #category : 'accessing' }
+JWTClaimsSet >> nbf: aString [
+	self at: 'nbf' put: aString
 ]
 
 { #category : 'accessing' }
@@ -204,6 +237,16 @@ JWTClaimsSet >> nonce [
 { #category : 'accessing' }
 JWTClaimsSet >> nonce: anObject [
 	self at: 'nonce' put: anObject
+]
+
+{ #category : 'accessing' }
+JWTClaimsSet >> notBefore [
+	^ self nbf
+]
+
+{ #category : 'accessing' }
+JWTClaimsSet >> notBefore: aString [
+	self nbf: aString
 ]
 
 { #category : 'accessing' }


### PR DESCRIPTION
…#at:put:

Add kid property directly to JOSEHeader.
Add notBefore and jwtId claim names to JWTClaimsSet